### PR TITLE
Add non-invasive nix shell integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,8 +47,12 @@ tags
 
 # Emacs
 *#
+.\#*
 .dir-locals.el
 TAGS
+
+# direnv
+.envrc
 
 # other
 .DS_Store

--- a/nix/stack-integration.nix
+++ b/nix/stack-integration.nix
@@ -1,0 +1,14 @@
+let
+  pkgs = import <nixpkgs> {};
+in
+
+pkgs.haskell.lib.buildStackProject {
+  ghc = pkgs.haskell.compiler.ghc8107;
+  name = "piece-of-cake-slayer";
+  # System dependencies needed at compilation time
+  buildInputs = [
+    pkgs.zlib
+    pkgs.postgresql
+    pkgs.protobuf
+  ];
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,23 @@
+let
+  pkgs = import <nixpkgs> {};
+
+  stack-wrapped = pkgs.symlinkJoin {
+    name = "stack";
+    paths = [ pkgs.stack ];
+    buildInputs = [ pkgs.makeWrapper ];
+    postBuild = ''
+      wrapProgram $out/bin/stack \
+        --add-flags "\
+          --nix \
+          --no-nix-pure \
+          --nix-shell-file=nix/stack-integration.nix \
+        "
+    '';
+  };
+
+in
+pkgs.mkShell {
+  # Do NOT use `stack`, otherwise system dependencies like `zlib` are missing at compilation
+  buildInputs = [ stack-wrapped ];
+  NIX_PATH = "nixpkgs=" + pkgs.path;
+}


### PR DESCRIPTION
Hi @chshersh,

I watched your [FunctionalFest presentation about cake-slayer](https://youtu.be/StgssIhwe2A), and I think this is a great project for the Haskell community. The choices you made really seem to address a lot of the reservations I've felt about investing in Haskell for a production application. I am still a Haskell beginner so I'm hoping that by grokking this template project, I can level myself up to proficiency.

Anyway, this change is based on a [Tweag blog post](https://www.tweag.io/blog/2022-06-02-haskell-stack-nix-shell/), which explains how to integrate Nix with stack in a non-invasive manner.

I tested the change on my NixOS machine by building...
```
stack build
```

running the server...
```
stack run piece-of-cake-slayer
```

and running the test commands from the readme...
```
$ curl localhost:8080/items

$ curl -XPOST \
    -H 'Content-Type: application/json' \
    localhost:8080/createItem \
    -d '{"tag": "Item", "text": "New item"}'

$ curl -XPOST \
    -H 'Content-Type: application/json' \
    localhost:8080/deleteItem \
    -d '1'
```

Finally, I ran the unit tests...
```
$ stack test
piece-of-cake-slayer> test (suite: piece-of-cake-slayer-test)
                                  

Unit tests
  Database tests
    Item
      Gets all items
      Creates new item
      Deletes item

Finished in 0.0185 seconds
3 examples, 0 failures

piece-of-cake-slayer> Test suite piece-of-cake-slayer-test passed
Completed 9 action(s).
```
